### PR TITLE
Fix RuboCop

### DIFF
--- a/rubocop/.rubocop.yml
+++ b/rubocop/.rubocop.yml
@@ -126,6 +126,9 @@ Style/BlockDelimiters:
     # are enforced).
     - braces_for_chaining
 
+Style/Documentation:
+  Enabled: false
+
 Style/MethodDefParentheses:
   EnforcedStyle: require_no_parentheses
   SupportedStyles:


### PR DESCRIPTION
- Rename rubocop.yml to .rubocop.yml
- Fix missing `AllCops:` key
- Customize `Metrics/LineLength` (i.e. from default `80` to custom `100` chars)
- Disable `Style/Documentation` cop