### PR TITLE
disable frozen string literal

### DIFF
--- a/rubocop/.rubocop.yml
+++ b/rubocop/.rubocop.yml
@@ -129,6 +129,9 @@ Style/BlockDelimiters:
 Style/Documentation:
   Enabled: false
 
+Style/FrozenStringLiteralComment:
+  Enabled: false
+
 Style/MethodDefParentheses:
   EnforcedStyle: require_no_parentheses
   SupportedStyles:


### PR DESCRIPTION
For ruby 2.3+ rubocop is printing a warning for each file not containing the magic comment `# frozen_string_literal: true`.
Ref: http://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/FrozenStringLiteralComment

I suggest to disable this as none of us is using it.